### PR TITLE
Bugsnag Integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'devise'
 gem 'omniauth-github'
 gem "octokit", "~> 4.0"
 gem "pundit"
+gem 'bugsnag'
 
 group :development, :test do
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,8 @@ GEM
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.14.3, < 2)
       sassc-rails (>= 2.0.0)
+    bugsnag (6.12.1)
+      concurrent-ruby (~> 1.0)
     builder (3.2.3)
     byebug (11.0.1)
     coderay (1.1.2)
@@ -259,6 +261,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.3.1)
+  bugsnag
   byebug
   coffee-rails (~> 4.2)
   devise

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,0 +1,3 @@
+Bugsnag.configure do |config|
+  config.api_key = ENV['BUGSNAG_API_KEY']
+end


### PR DESCRIPTION
Hello!

I followed the official rails integration [docs](https://docs.bugsnag.com/platforms/ruby/rails/#logging-breadcrumbs). 

There's only change from the default configurations to get the API key from the environments.

```ruby
# app_root/config/initializers/bugsnag.rb
Bugsnag.configure do |config|
  config.api_key = ENV['BUGSNAG_API_KEY']
end
```


### Integration
Here's the .env file
```
GITHUB_APP_ID=XXXX
GITHUB_APP_SECRET=XXXXX

# PRODUCTION
BUGSNAG_API_KEY=XXXXX
```
I tested it by my own trial account by raising an error in `welcome#index`.
![Screen Shot 2019-10-25 at 1 41 56 PM](https://user-images.githubusercontent.com/46192266/67566121-abd69080-f72f-11e9-926a-ea3c4b9a1c24.png)

### Slack Integration
Slack integration is tested as well. It worked well. I only followed the official [docs](https://docs.bugsnag.com/product/integrations/slack/).

![Screen Shot 2019-10-25 at 1 56 19 PM](https://user-images.githubusercontent.com/46192266/67565997-5ef2ba00-f72f-11e9-8b64-749e06e8a78b.png)


---

### Inaccurate Points

We probably won't use bugsnag on development&test environments. In my opinion, we should install bugsnag dependency only on production. For now, it's in the general dependency list.
My Suggestion is: 
```ruby
# app_root/Gemfile
group :production do
  gem 'bugsnag'
end
```